### PR TITLE
make our PROMPT_COMMAND function forward onto previous PROMPT_COMMAND

### DIFF
--- a/src/history_search.bash
+++ b/src/history_search.bash
@@ -9,6 +9,11 @@ record_external_history() {
         "@@@ " >> $ETERNAL_HISTORY_FILE
     # must do it in seperate line otherwise newline is not properly escaped
     history 1 | perl -pe 's/^\s*\d+\s*\d+\s*//' >> $ETERNAL_HISTORY_FILE
+
+    # call out to the previous PROMPT_COMMAND, if there was one.
+    "$@"
 }
 
-export PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND}"record_external_history
+if [[ ! "${PROMPT_COMMAND:-}" =~ "^record_external_history" ]]; then
+    export PROMPT_COMMAND="record_external_history ${PROMPT_COMMAND:+$PROMPT_COMMAND}"
+fi


### PR DESCRIPTION
Firstly, thanks for writing this. I had been looking around for a simple history manager (because I'm bored of bash's default behaviour of only preserving history of one of your open shells at random when you shut down), but most of the rust-based ones try to take over the ^R shortcut, and drop you into a fullscreen TUI whenever you use them, which is a bit jarring. This UI is much nicer and less intrusive, but gives me confidence because I know that it's there when I need it.

It took a bit of setting up though, and I had to make some edits in order to debug things and get history recording working.

I'm not sure how the previous implementation was designed to work, but for me it was printing:

```
bash: starship_precmdrecord_external_history: command not found
```
and failing to render my starship prompt.

I haven't done very extensive testing yet (I'm currently trying out VSCode's session resumption nonsense, so getting a fresh bash session is more of a rigmarole than I'd like). I'm also pretty sure that "$@" isn't enough to cover all edge cases here, but I'm also not sure how best to try breaking it.

Note that the vscode shell integration currently does this:

```bash

...

__vsc_prompt_cmd_original() {
	__vsc_status="$?"
	# Evaluate the original PROMPT_COMMAND similarly to how bash would normally
	# See https://unix.stackexchange.com/a/672843 for technique
	if [[ ${#__vsc_original_prompt_command[@]} -gt 1 ]]; then
		for cmd in "${__vsc_original_prompt_command[@]}"; do
			__vsc_status="$?"
			eval "${cmd:-}"
		done
	else
		__vsc_restore_exit_code "${__vsc_status}"
		eval "${__vsc_original_prompt_command:-}"
	fi
	__vsc_precmd
}

__vsc_prompt_cmd() {
	__vsc_status="$?"
	__vsc_precmd
}

# PROMPT_COMMAND arrays and strings seem to be handled the same (handling only the first entry of
# the array?)
__vsc_original_prompt_command=$PROMPT_COMMAND

if [[ -z "${bash_preexec_imported:-}" ]]; then
	if [[ -n "$__vsc_original_prompt_command" && "$__vsc_original_prompt_command" != "__vsc_prompt_cmd" ]]; then
		PROMPT_COMMAND=__vsc_prompt_cmd_original
	else
		PROMPT_COMMAND=__vsc_prompt_cmd
	fi
fi
```

(you can read the whole thing by typing:
```
code "$(code --locate-shell-integration-path bash)"
```
)

Starship's `starship init bash --print-full-init` prints this, which is pretty involved: https://github.com/starship/starship/blob/018b077630bd6eb6dc858e65c04bbfd19b40198c/src/init/starship.bash

If you would prefer for me to follow either of the above approaches, I'm happy to re-work my patch. At the moment it's just what "works for me".